### PR TITLE
add benchmarks for versions with more args

### DIFF
--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -16,6 +16,10 @@ static DATE: &str = "2014-11-28";
 static T: &str = "T";
 static TIME: &str = "12:00:09Z";
 static DATETIME: &str = "2014-11-28T12:00:09Z";
+const SCHEMA_NAME: &str = "eth";
+const SCHEMA_DATETIME: &str = "eth2014-11-28T12:00:09Z";
+const SOL_FN_SELECTOR: &str = "8da5cb5b";
+const SCHEMA_SELECTOR_DATETIME: &str = "eth8da5cb5b2014-11-28T12:00:09Z";
 
 ////
 #[bench]
@@ -56,10 +60,32 @@ fn array_join_long(b: &mut Bencher) {
     });
 }
 
+#[bench]
+fn array_join_4_member(b: &mut Bencher) {
+    b.iter(|| {
+        let s: &str = &[SCHEMA_NAME, DATE, T, TIME].join("");
+        test::black_box(s);
+    });
+}
+
 #[test]
-fn array_join_long_test() {
-    let datetime: &str = &[DATE, T, TIME].join("");
-    assert_eq!(String::from(DATETIME), datetime);
+fn array_join_4_member_test() {
+    let s: &str = &[DATE, T, TIME].join("");
+    assert_eq!(String::from(SCHEMA_DATETIME), s);
+}
+
+#[bench]
+fn array_join_5_member(b: &mut Bencher) {
+    b.iter(|| {
+        let s: &str = &[SCHEMA_NAME, DATE, T, TIME].join("");
+        test::black_box(s);
+    });
+}
+
+#[test]
+fn array_join_5_member_test() {
+    let s: &str = &[SCHEMA_NAME, SOL_FN_SELECTOR, DATE, T, TIME].join("");
+    assert_eq!(String::from(SCHEMA_SELECTOR_DATETIME), s);
 }
 
 ////
@@ -110,6 +136,37 @@ fn format_macro_test() {
     let datetime: &str = &format!("{}{}{}", DATE, T, TIME);
     assert_eq!(String::from(DATETIME), datetime);
 }
+
+////
+#[bench]
+fn format_macro_3_member(b: &mut Bencher) {
+    b.iter(|| {
+        let s: &str = &format!("{}{}T{}", SCHEMA_NAME, DATE, TIME);
+        test::black_box(s);
+    });
+}
+
+#[test]
+fn format_macro_3_member_test() {
+    let datetime: &str = &format!("{}{}{}{}", SCHEMA_NAME, DATE, T, TIME);
+    assert_eq!(String::from(SCHEMA_DATETIME), datetime);
+}
+
+////
+#[bench]
+fn format_macro_4_member(b: &mut Bencher) {
+    b.iter(|| {
+        let s: &str = &format!("{}{}{}T{}", SCHEMA_NAME, SOL_FN_SELECTOR, DATE, TIME);
+        test::black_box(s);
+    });
+}
+
+#[test]
+fn format_macro_4_member_test() {
+    let datetime: &str = &format!("{}{}{}{}{}", SCHEMA_NAME, SOL_FN_SELECTOR, DATE, T, TIME);
+    assert_eq!(String::from(SCHEMA_SELECTOR_DATETIME), datetime);
+}
+
 
 /// Implicit named arguments were added in Rust 1.58
 #[bench]

--- a/benches/lib.rs
+++ b/benches/lib.rs
@@ -16,10 +16,10 @@ static DATE: &str = "2014-11-28";
 static T: &str = "T";
 static TIME: &str = "12:00:09Z";
 static DATETIME: &str = "2014-11-28T12:00:09Z";
-const SCHEMA_NAME: &str = "eth";
-const SCHEMA_DATETIME: &str = "eth2014-11-28T12:00:09Z";
-const SOL_FN_SELECTOR: &str = "8da5cb5b";
-const SCHEMA_SELECTOR_DATETIME: &str = "eth8da5cb5b2014-11-28T12:00:09Z";
+static SCHEMA_NAME: &str = "eth";
+static SCHEMA_DATETIME: &str = "eth2014-11-28T12:00:09Z";
+static SOL_FN_SELECTOR: &str = "8da5cb5b";
+static SCHEMA_SELECTOR_DATETIME: &str = "eth8da5cb5b2014-11-28T12:00:09Z";
 
 ////
 #[bench]


### PR DESCRIPTION
results from my m1 pro MBP - the `array.join("")` advantage actually gets stronger the more arguments you have, but maybe we should actually be using the concat macro ?
```
test array_concat                                 ... bench:          26 ns/iter (+/- 1)
test array_join                                   ... bench:          22 ns/iter (+/- 1)
test array_join_4_member                          ... bench:          30 ns/iter (+/- 1)
test array_join_5_member                          ... bench:          31 ns/iter (+/- 0)
test array_join_long                              ... bench:          26 ns/iter (+/- 0)
test collect_from_array_to_string                 ... bench:          49 ns/iter (+/- 1)
test collect_from_vec_to_string                   ... bench:          52 ns/iter (+/- 2)
test concat_in_place_macro                        ... bench:          19 ns/iter (+/- 0)
test concat_string_macro                          ... bench:          15 ns/iter (+/- 0)
test concat_strs_macro                            ... bench:          15 ns/iter (+/- 1)
test format_macro                                 ... bench:          63 ns/iter (+/- 1)
test format_macro_3_member                        ... bench:          86 ns/iter (+/- 2)
test format_macro_4_member                        ... bench:          93 ns/iter (+/- 2)
test format_macro_implicit_args                   ... bench:          62 ns/iter (+/- 4)
test from_bytes                                   ... bench:           0 ns/iter (+/- 0)
test joinery                                      ... bench:          59 ns/iter (+/- 2)
test mut_string_push_str                          ... bench:          40 ns/iter (+/- 1)
test mut_string_push_string                       ... bench:          85 ns/iter (+/- 3)
test mut_string_with_capacity_push_str            ... bench:          16 ns/iter (+/- 0)
test mut_string_with_capacity_push_str_char       ... bench:          15 ns/iter (+/- 0)
test mut_string_with_too_little_capacity_push_str ... bench:          58 ns/iter (+/- 1)
test mut_string_with_too_much_capacity_push_str   ... bench:          16 ns/iter (+/- 0)
test string_concat_macro                          ... bench:          16 ns/iter (+/- 0)
test string_from_all                              ... bench:          67 ns/iter (+/- 3)
test string_from_plus_op                          ... bench:          41 ns/iter (+/- 2)
test to_owned_plus_op                             ... bench:          41 ns/iter (+/- 1)
test to_string_plus_op                            ... bench:          41 ns/iter (+/- 1)
```
